### PR TITLE
Add more resource types into package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ This package builds a mart of tables from dbt artifacts loaded into a table. It 
 Models included:
 
 - `dim_dbt__models`
-- `fct_dbt__model_executions`
-- `fct_dbt__latest_full_model_executions`
+- `dim_dbt__seeds`
+- `dim_dbt__snapshots`
+- `dim_dbt__tests`
 - `fct_dbt__critical_path`
-- `fct_dbt_run_results`
+- `fct_dbt__latest_full_model_executions`
+- `fct_dbt__model_executions`
+- `fct_dbt__run_results`
+- `fct_dbt__seed_executions`
+- `fct_dbt__snapshot_executions`
+- `fct_dbt__test_executions`
 
 The critical path model determines the slowest route through your DAG, which provides you with the information needed to make a targeted effort to reducing `dbt run` times. For example:
 

--- a/models/incremental/dim_dbt__exposures.sql
+++ b/models/incremental/dim_dbt__exposures.sql
@@ -1,20 +1,20 @@
 {{
   config(
     materialized='incremental',
-    unique_key='manifest_model_id'
+    unique_key='manifest_exposure_id'
     )
 }}
 
-with dbt_models as (
+with dbt_exposures as (
 
     select * from {{ ref('stg_dbt__exposures') }}
 
 ),
 
-dbt_models_incremental as (
+dbt_exposures_incremental as (
 
     select *
-    from dbt_models
+    from dbt_exposures
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
@@ -26,7 +26,7 @@ dbt_models_incremental as (
 fields as (
 
      select
-        t.manifest_model_id,
+        t.manifest_exposure_id,
         t.command_invocation_id,
         t.dbt_cloud_run_id,
         t.artifact_generated_at,
@@ -37,7 +37,7 @@ fields as (
         t.maturity,
         f.value::string as output_feeds,
         t.package_name
-    from dbt_models_incremental as t,
+    from dbt_exposures_incremental as t,
     lateral flatten(input => depends_on_nodes) as f
 
 )

--- a/models/incremental/dim_dbt__seeds.sql
+++ b/models/incremental/dim_dbt__seeds.sql
@@ -1,0 +1,41 @@
+{{ config( materialized='incremental', unique_key='manifest_model_id' ) }}
+
+with dbt_models as (
+
+    select * from {{ ref('stg_dbt__seeds') }}
+
+),
+
+dbt_models_incremental as (
+
+    select *
+    from dbt_models
+
+    {% if is_incremental() %}
+    -- this filter will only be applied on an incremental run
+    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    {% endif %}
+
+),
+
+fields as (
+
+    select
+        manifest_model_id,
+        command_invocation_id,
+        dbt_cloud_run_id,
+        artifact_generated_at,
+        node_id,
+        model_database,
+        model_schema,
+        name,
+        depends_on_nodes,
+        package_name,
+        model_path,
+        checksum,
+        model_materialization
+    from dbt_models_incremental
+
+)
+
+select * from fields

--- a/models/incremental/dim_dbt__seeds.sql
+++ b/models/incremental/dim_dbt__seeds.sql
@@ -1,15 +1,15 @@
-{{ config( materialized='incremental', unique_key='manifest_model_id' ) }}
+{{ config( materialized='incremental', unique_key='manifest_seed_id' ) }}
 
-with dbt_models as (
+with dbt_seeds as (
 
     select * from {{ ref('stg_dbt__seeds') }}
 
 ),
 
-dbt_models_incremental as (
+dbt_seeds_incremental as (
 
     select *
-    from dbt_models
+    from dbt_seeds
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
@@ -21,20 +21,19 @@ dbt_models_incremental as (
 fields as (
 
     select
-        manifest_model_id,
+        manifest_seed_id,
         command_invocation_id,
         dbt_cloud_run_id,
         artifact_generated_at,
         node_id,
-        model_database,
-        model_schema,
+        seed_database,
+        seed_schema,
         name,
         depends_on_nodes,
         package_name,
-        model_path,
-        checksum,
-        model_materialization
-    from dbt_models_incremental
+        seed_path,
+        checksum
+    from dbt_seeds_incremental
 
 )
 

--- a/models/incremental/dim_dbt__snapshots.sql
+++ b/models/incremental/dim_dbt__snapshots.sql
@@ -1,15 +1,15 @@
-{{ config( materialized='incremental', unique_key='manifest_model_id' ) }}
+{{ config( materialized='incremental', unique_key='manifest_snapshot_id' ) }}
 
-with dbt_models as (
+with dbt_snapshots as (
 
     select * from {{ ref('stg_dbt__snapshots') }}
 
 ),
 
-dbt_models_incremental as (
+dbt_snapshots_incremental as (
 
     select *
-    from dbt_models
+    from dbt_snapshots
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
@@ -21,20 +21,19 @@ dbt_models_incremental as (
 fields as (
 
     select
-        manifest_model_id,
+        manifest_snapshot_id,
         command_invocation_id,
         dbt_cloud_run_id,
         artifact_generated_at,
         node_id,
-        model_database,
-        model_schema,
+        snapshot_database,
+        snapshot_schema,
         name,
         depends_on_nodes,
         package_name,
-        model_path,
-        checksum,
-        model_materialization
-    from dbt_models_incremental
+        snapshot_path,
+        checksum
+    from dbt_snapshots_incremental
 
 )
 

--- a/models/incremental/dim_dbt__snapshots.sql
+++ b/models/incremental/dim_dbt__snapshots.sql
@@ -1,0 +1,41 @@
+{{ config( materialized='incremental', unique_key='manifest_model_id' ) }}
+
+with dbt_models as (
+
+    select * from {{ ref('stg_dbt__snapshots') }}
+
+),
+
+dbt_models_incremental as (
+
+    select *
+    from dbt_models
+
+    {% if is_incremental() %}
+    -- this filter will only be applied on an incremental run
+    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    {% endif %}
+
+),
+
+fields as (
+
+    select
+        manifest_model_id,
+        command_invocation_id,
+        dbt_cloud_run_id,
+        artifact_generated_at,
+        node_id,
+        model_database,
+        model_schema,
+        name,
+        depends_on_nodes,
+        package_name,
+        model_path,
+        checksum,
+        model_materialization
+    from dbt_models_incremental
+
+)
+
+select * from fields

--- a/models/incremental/dim_dbt__tests.sql
+++ b/models/incremental/dim_dbt__tests.sql
@@ -27,6 +27,7 @@ fields as (
         artifact_generated_at,
         node_id,
         name,
+        depends_on_nodes,
         package_name,
         test_path
     from dbt_tests_incremental

--- a/models/incremental/dim_dbt__tests.sql
+++ b/models/incremental/dim_dbt__tests.sql
@@ -1,4 +1,4 @@
-{{ config( materialized='incremental', unique_key='manifest_source_id' ) }}
+{{ config( materialized='incremental', unique_key='manifest_test_id' ) }}
 
 with dbt_tests as (
 
@@ -21,7 +21,7 @@ dbt_tests_incremental as (
 fields as (
 
     select
-        manifest_source_id,
+        manifest_test_id,
         command_invocation_id,
         dbt_cloud_run_id,
         artifact_generated_at,

--- a/models/incremental/dim_dbt__tests.sql
+++ b/models/incremental/dim_dbt__tests.sql
@@ -1,0 +1,39 @@
+{{ config( materialized='incremental', unique_key='manifest_source_id' ) }}
+
+with dbt_tests as (
+
+    select * from {{ ref('stg_dbt__tests') }}
+
+),
+
+dbt_tests_incremental as (
+
+    select *
+    from dbt_tests
+
+    {% if is_incremental() %}
+    -- this filter will only be applied on an incremental run
+    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    {% endif %}
+
+),
+
+fields as (
+
+    select
+        manifest_source_id,
+        command_invocation_id,
+        dbt_cloud_run_id,
+        artifact_generated_at,
+        node_id,
+        name,
+        source_name,
+        source_schema,
+        package_name,
+        relation_name,
+        source_path
+    from dbt_tests_incremental
+
+)
+
+select * from fields

--- a/models/incremental/dim_dbt__tests.sql
+++ b/models/incremental/dim_dbt__tests.sql
@@ -27,11 +27,8 @@ fields as (
         artifact_generated_at,
         node_id,
         name,
-        source_name,
-        source_schema,
         package_name,
-        relation_name,
-        source_path
+        test_path
     from dbt_tests_incremental
 
 )

--- a/models/incremental/fct_dbt__seed_executions.sql
+++ b/models/incremental/fct_dbt__seed_executions.sql
@@ -1,0 +1,68 @@
+{{ config( materialized='incremental', unique_key='model_execution_id' ) }}
+
+with models as (
+
+    select *
+    from {{ ref('dim_dbt__seeds') }}
+
+),
+
+model_executions as (
+
+    select *
+    from {{ ref('stg_dbt__seed_executions') }}
+
+),
+
+model_executions_incremental as (
+
+    select *
+    from model_executions
+
+    {% if is_incremental() %}
+    -- this filter will only be applied on an incremental run
+    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    {% endif %}
+
+),
+
+model_executions_with_materialization as (
+
+    select
+        model_executions_incremental.*,
+        models.model_materialization,
+        models.model_schema,
+        models.name
+    from model_executions_incremental
+    left join models on
+        (
+            model_executions_incremental.command_invocation_id = models.command_invocation_id
+            or model_executions_incremental.dbt_cloud_run_id = models.dbt_cloud_run_id
+        )
+        and model_executions_incremental.node_id = models.node_id
+
+),
+
+fields as (
+
+    select
+        model_execution_id,
+        command_invocation_id,
+        dbt_cloud_run_id,
+        artifact_generated_at,
+        was_full_refresh,
+        node_id,
+        thread_id,
+        status,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected,
+        model_materialization,
+        model_schema,
+        name
+    from model_executions_with_materialization
+
+)
+
+select * from fields

--- a/models/incremental/fct_dbt__snapshot_executions.sql
+++ b/models/incremental/fct_dbt__snapshot_executions.sql
@@ -1,0 +1,68 @@
+{{ config( materialized='incremental', unique_key='model_execution_id' ) }}
+
+with models as (
+
+    select *
+    from {{ ref('dim_dbt__snapshots') }}
+
+),
+
+model_executions as (
+
+    select *
+    from {{ ref('stg_dbt__snapshot_executions') }}
+
+),
+
+model_executions_incremental as (
+
+    select *
+    from model_executions
+
+    {% if is_incremental() %}
+    -- this filter will only be applied on an incremental run
+    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    {% endif %}
+
+),
+
+model_executions_with_materialization as (
+
+    select
+        model_executions_incremental.*,
+        models.model_materialization,
+        models.model_schema,
+        models.name
+    from model_executions_incremental
+    left join models on
+        (
+            model_executions_incremental.command_invocation_id = models.command_invocation_id
+            or model_executions_incremental.dbt_cloud_run_id = models.dbt_cloud_run_id
+        )
+        and model_executions_incremental.node_id = models.node_id
+
+),
+
+fields as (
+
+    select
+        model_execution_id,
+        command_invocation_id,
+        dbt_cloud_run_id,
+        artifact_generated_at,
+        was_full_refresh,
+        node_id,
+        thread_id,
+        status,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected,
+        model_materialization,
+        model_schema,
+        name
+    from model_executions_with_materialization
+
+)
+
+select * from fields

--- a/models/incremental/fct_dbt__test_executions.sql
+++ b/models/incremental/fct_dbt__test_executions.sql
@@ -1,16 +1,16 @@
-{{ config( materialized='incremental', unique_key='model_execution_id' ) }}
+{{ config( materialized='incremental', unique_key='test_execution_id' ) }}
 
-with model_executions as (
+with test_executions as (
 
     select *
     from {{ ref('stg_dbt__test_executions') }}
 
 ),
 
-model_executions_incremental as (
+test_executions_incremental as (
 
     select *
-    from model_executions
+    from test_executions
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
@@ -22,7 +22,7 @@ model_executions_incremental as (
 fields as (
 
     select
-        model_execution_id,
+        test_execution_id,
         command_invocation_id,
         dbt_cloud_run_id,
         artifact_generated_at,
@@ -34,7 +34,7 @@ fields as (
         query_completed_at,
         total_node_runtime,
         rows_affected
-    from model_executions_incremental
+    from test_executions_incremental
 
 )
 

--- a/models/staging/stg_dbt__exposures.sql
+++ b/models/staging/stg_dbt__exposures.sql
@@ -35,7 +35,7 @@ flatten as (
 surrogate_key as (
 
     select
-        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_model_id,
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_exposure_id,
         command_invocation_id,
         dbt_cloud_run_id,
         artifact_generated_at,

--- a/models/staging/stg_dbt__run_results.sql
+++ b/models/staging/stg_dbt__run_results.sql
@@ -17,7 +17,7 @@ dbt_run as (
 
     select *
     from run_results
-    where data:args:which = 'run'
+    where data:args:which in ('run', 'seed', 'snapshot', 'test')
 
 ),
 

--- a/models/staging/stg_dbt__seed_executions.sql
+++ b/models/staging/stg_dbt__seed_executions.sql
@@ -1,0 +1,72 @@
+with base as (
+
+    select *
+    from {{ ref('stg_dbt__artifacts') }}
+
+),
+
+run_results as (
+
+    select *
+    from base
+    where artifact_type = 'run_results.json'
+
+),
+
+dbt_run as (
+
+    select *
+    from run_results
+    where data:args:which = 'seed'
+
+),
+
+fields as (
+
+    select
+        command_invocation_id,
+        dbt_cloud_run_id,
+        generated_at as artifact_generated_at,
+        coalesce(data:args:full_refresh, 'false')::boolean as was_full_refresh,
+        result.value:unique_id::string as node_id,
+        split(result.value:thread_id::string, '-')[1]::integer as thread_id,
+        result.value:status::string as status,
+        result.value:message::string as message,
+
+        -- The first item in the timing array is the model-level `compile`
+        result.value:timing[0]:started_at::timestamp_ntz as compile_started_at,
+
+        -- The second item in the timing array is `execute`.
+        result.value:timing[1]:completed_at::timestamp_ntz as query_completed_at,
+
+        -- Confusingly, this does not match the delta of the above two timestamps.
+        -- should we calculate it instead?
+        coalesce(result.value:execution_time::float, 0) as total_node_runtime,
+
+        result.value:adapter_response:rows_affected::int as rows_affected
+    from dbt_run,
+    lateral flatten(input => data:results) as result
+
+),
+
+surrogate_key as (
+
+    select
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as model_execution_id,
+        command_invocation_id,
+        dbt_cloud_run_id,
+        artifact_generated_at,
+        was_full_refresh,
+        node_id,
+        thread_id,
+        status,
+        message,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected
+    from fields
+
+)
+
+select * from surrogate_key

--- a/models/staging/stg_dbt__seed_executions.sql
+++ b/models/staging/stg_dbt__seed_executions.sql
@@ -33,7 +33,7 @@ fields as (
         result.value:status::string as status,
         result.value:message::string as message,
 
-        -- The first item in the timing array is the model-level `compile`
+        -- The first item in the timing array is the seed-level `compile`
         result.value:timing[0]:started_at::timestamp_ntz as compile_started_at,
 
         -- The second item in the timing array is `execute`.
@@ -52,7 +52,7 @@ fields as (
 surrogate_key as (
 
     select
-        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as model_execution_id,
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as seed_execution_id,
         command_invocation_id,
         dbt_cloud_run_id,
         artifact_generated_at,

--- a/models/staging/stg_dbt__seeds.sql
+++ b/models/staging/stg_dbt__seeds.sql
@@ -1,0 +1,57 @@
+with base as (
+
+    select *
+    from {{ ref('stg_dbt__artifacts') }}
+
+),
+
+manifests as (
+
+    select *
+    from base
+    where artifact_type = 'manifest.json'
+
+),
+
+flatten as (
+
+    select
+        command_invocation_id,
+        dbt_cloud_run_id,
+        generated_at as artifact_generated_at,
+        node.key as node_id,
+        node.value:database::string as model_database,
+        node.value:schema::string as model_schema,
+        node.value:name::string as name,
+        to_array(node.value:depends_on:nodes) as depends_on_nodes,
+        node.value:package_name::string as package_name,
+        node.value:path::string as model_path,
+        node.value:checksum.checksum::string as checksum,
+        node.value:config.materialized::string as model_materialization
+    from manifests,
+    lateral flatten(input => data:nodes) as node
+    where node.value:resource_type = 'seed'
+
+),
+
+surrogate_key as (
+
+    select
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_model_id,
+        command_invocation_id,
+        dbt_cloud_run_id,
+        artifact_generated_at,
+        node_id,
+        model_database,
+        model_schema,
+        name,
+        depends_on_nodes,
+        package_name,
+        model_path,
+        checksum,
+        model_materialization
+    from flatten
+
+)
+
+select * from surrogate_key

--- a/models/staging/stg_dbt__seeds.sql
+++ b/models/staging/stg_dbt__seeds.sql
@@ -20,14 +20,13 @@ flatten as (
         dbt_cloud_run_id,
         generated_at as artifact_generated_at,
         node.key as node_id,
-        node.value:database::string as model_database,
-        node.value:schema::string as model_schema,
+        node.value:database::string as seed_database,
+        node.value:schema::string as seed_schema,
         node.value:name::string as name,
         to_array(node.value:depends_on:nodes) as depends_on_nodes,
         node.value:package_name::string as package_name,
-        node.value:path::string as model_path,
-        node.value:checksum.checksum::string as checksum,
-        node.value:config.materialized::string as model_materialization
+        node.value:path::string as seed_path,
+        node.value:checksum.checksum::string as checksum
     from manifests,
     lateral flatten(input => data:nodes) as node
     where node.value:resource_type = 'seed'
@@ -37,19 +36,18 @@ flatten as (
 surrogate_key as (
 
     select
-        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_model_id,
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_seed_id,
         command_invocation_id,
         dbt_cloud_run_id,
         artifact_generated_at,
         node_id,
-        model_database,
-        model_schema,
+        seed_database,
+        seed_schema,
         name,
         depends_on_nodes,
         package_name,
-        model_path,
-        checksum,
-        model_materialization
+        seed_path,
+        checksum
     from flatten
 
 )

--- a/models/staging/stg_dbt__snapshot_executions.sql
+++ b/models/staging/stg_dbt__snapshot_executions.sql
@@ -1,0 +1,72 @@
+with base as (
+
+    select *
+    from {{ ref('stg_dbt__artifacts') }}
+
+),
+
+run_results as (
+
+    select *
+    from base
+    where artifact_type = 'run_results.json'
+
+),
+
+dbt_run as (
+
+    select *
+    from run_results
+    where data:args:which = 'snapshot'
+
+),
+
+fields as (
+
+    select
+        command_invocation_id,
+        dbt_cloud_run_id,
+        generated_at as artifact_generated_at,
+        coalesce(data:args:full_refresh, 'false')::boolean as was_full_refresh,
+        result.value:unique_id::string as node_id,
+        split(result.value:thread_id::string, '-')[1]::integer as thread_id,
+        result.value:status::string as status,
+        result.value:message::string as message,
+
+        -- The first item in the timing array is the model-level `compile`
+        result.value:timing[0]:started_at::timestamp_ntz as compile_started_at,
+
+        -- The second item in the timing array is `execute`.
+        result.value:timing[1]:completed_at::timestamp_ntz as query_completed_at,
+
+        -- Confusingly, this does not match the delta of the above two timestamps.
+        -- should we calculate it instead?
+        coalesce(result.value:execution_time::float, 0) as total_node_runtime,
+
+        result.value:adapter_response:rows_affected::int as rows_affected
+    from dbt_run,
+    lateral flatten(input => data:results) as result
+
+),
+
+surrogate_key as (
+
+    select
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as model_execution_id,
+        command_invocation_id,
+        dbt_cloud_run_id,
+        artifact_generated_at,
+        was_full_refresh,
+        node_id,
+        thread_id,
+        status,
+        message,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected
+    from fields
+
+)
+
+select * from surrogate_key

--- a/models/staging/stg_dbt__snapshot_executions.sql
+++ b/models/staging/stg_dbt__snapshot_executions.sql
@@ -33,7 +33,7 @@ fields as (
         result.value:status::string as status,
         result.value:message::string as message,
 
-        -- The first item in the timing array is the model-level `compile`
+        -- The first item in the timing array is the snapshot-level `compile`
         result.value:timing[0]:started_at::timestamp_ntz as compile_started_at,
 
         -- The second item in the timing array is `execute`.
@@ -52,7 +52,7 @@ fields as (
 surrogate_key as (
 
     select
-        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as model_execution_id,
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as snapshot_execution_id,
         command_invocation_id,
         dbt_cloud_run_id,
         artifact_generated_at,

--- a/models/staging/stg_dbt__snapshots.sql
+++ b/models/staging/stg_dbt__snapshots.sql
@@ -20,14 +20,13 @@ flatten as (
         dbt_cloud_run_id,
         generated_at as artifact_generated_at,
         node.key as node_id,
-        node.value:database::string as model_database,
-        node.value:schema::string as model_schema,
+        node.value:database::string as snapshot_database,
+        node.value:schema::string as snapshot_schema,
         node.value:name::string as name,
         to_array(node.value:depends_on:nodes) as depends_on_nodes,
         node.value:package_name::string as package_name,
-        node.value:path::string as model_path,
-        node.value:checksum.checksum::string as checksum,
-        node.value:config.materialized::string as model_materialization
+        node.value:path::string as snapshot_path,
+        node.value:checksum.checksum::string as checksum
     from manifests,
     lateral flatten(input => data:nodes) as node
     where node.value:resource_type = 'snapshot'
@@ -37,19 +36,18 @@ flatten as (
 surrogate_key as (
 
     select
-        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_model_id,
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_snapshot_id,
         command_invocation_id,
         dbt_cloud_run_id,
         artifact_generated_at,
         node_id,
-        model_database,
-        model_schema,
+        snapshot_database,
+        snapshot_schema,
         name,
         depends_on_nodes,
         package_name,
-        model_path,
-        checksum,
-        model_materialization
+        snapshot_path,
+        checksum
     from flatten
 
 )

--- a/models/staging/stg_dbt__snapshots.sql
+++ b/models/staging/stg_dbt__snapshots.sql
@@ -1,0 +1,57 @@
+with base as (
+
+    select *
+    from {{ ref('stg_dbt__artifacts') }}
+
+),
+
+manifests as (
+
+    select *
+    from base
+    where artifact_type = 'manifest.json'
+
+),
+
+flatten as (
+
+    select
+        command_invocation_id,
+        dbt_cloud_run_id,
+        generated_at as artifact_generated_at,
+        node.key as node_id,
+        node.value:database::string as model_database,
+        node.value:schema::string as model_schema,
+        node.value:name::string as name,
+        to_array(node.value:depends_on:nodes) as depends_on_nodes,
+        node.value:package_name::string as package_name,
+        node.value:path::string as model_path,
+        node.value:checksum.checksum::string as checksum,
+        node.value:config.materialized::string as model_materialization
+    from manifests,
+    lateral flatten(input => data:nodes) as node
+    where node.value:resource_type = 'snapshot'
+
+),
+
+surrogate_key as (
+
+    select
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_model_id,
+        command_invocation_id,
+        dbt_cloud_run_id,
+        artifact_generated_at,
+        node_id,
+        model_database,
+        model_schema,
+        name,
+        depends_on_nodes,
+        package_name,
+        model_path,
+        checksum,
+        model_materialization
+    from flatten
+
+)
+
+select * from surrogate_key

--- a/models/staging/stg_dbt__test_executions.sql
+++ b/models/staging/stg_dbt__test_executions.sql
@@ -33,7 +33,7 @@ fields as (
         result.value:status::string as status,
         result.value:message::string as message,
 
-        -- The first item in the timing array is the model-level `compile`
+        -- The first item in the timing array is the test-level `compile`
         result.value:timing[0]:started_at::timestamp_ntz as compile_started_at,
 
         -- The second item in the timing array is `execute`.
@@ -52,7 +52,7 @@ fields as (
 surrogate_key as (
 
     select
-        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as model_execution_id,
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as test_execution_id,
         command_invocation_id,
         dbt_cloud_run_id,
         artifact_generated_at,

--- a/models/staging/stg_dbt__tests.sql
+++ b/models/staging/stg_dbt__tests.sql
@@ -1,0 +1,51 @@
+with base as (
+
+    select *
+    from {{ ref('stg_dbt__artifacts') }}
+
+),
+
+manifests as (
+
+    select *
+    from base
+    where artifact_type = 'manifest.json'
+
+),
+
+flatten as (
+
+    select
+        command_invocation_id,
+        dbt_cloud_run_id,
+        generated_at as artifact_generated_at,
+        node.key as node_id,
+        node.value:name::string as name,
+        to_array(node.value:depends_on:nodes) as depends_on_nodes,
+        node.value:package_name::string as package_name,
+        node.value:path::string as test_path
+
+    from manifests,
+    lateral flatten(input => data:nodes) as node
+    where node.value:resource_type = 'test'
+
+),
+
+surrogate_key as (
+
+    select
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_test_id,
+        command_invocation_id,
+        dbt_cloud_run_id,
+        artifact_generated_at,
+        node_id,
+        name,
+        depends_on_nodes,
+        package_name,
+        test_path
+
+    from flatten
+
+)
+
+select * from surrogate_key


### PR DESCRIPTION
This PR creates parallel `dim_dbt__<resource>` and `fct_dbt__<resource>_executions` models for the snapshot, seed, and test resource types.

- Add seed, snapshot, test dimensions and executions
- Change run_results to include seed, snapshot, test
